### PR TITLE
#3: Output Guile ports for PNG files must be binary

### DIFF
--- a/guile/ex-plot1.scm
+++ b/guile/ex-plot1.scm
@@ -8,7 +8,7 @@
 	(draw-c-curve plotter (* 0.5 (- dx dy)) (* 0.5 (+ dx dy)) (+ order 1))
 	(draw-c-curve plotter (* 0.5 (+ dx dy)) (* 0.5 (- dy dx)) (+ order 1)))))
 
-(define fp (open-output-file "tmp.png"))
+(define fp (open-output-file "tmp.png" #:binary #t))
 (define param (newplparams))
 (setplparam! param "BITMAPSIZE" "400x400")
 (define plotter (newpl "png" fp (current-error-port) param))

--- a/guile/ex-plot2.scm
+++ b/guile/ex-plot2.scm
@@ -16,7 +16,7 @@
 
 (define plotter-params (newplparams))
 (setplparam! plotter-params "PAGESIZE" "letter")
-(define fp (open-output-file "tmp.png"))
+(define fp (open-output-file "tmp.png" #:binary #t))
 (define plotter (newpl "png"
 		       fp
 		       (current-error-port)


### PR DESCRIPTION
Closes #3 